### PR TITLE
fix: always includes default props

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,76 @@ I found the name `getListDetails` a bit confusing, so I renamed it to `getListIt
 ### No `get` API
 
 The `get` API is omitted in this library, because more specific APIs(`getList`, `getObject`, `getListItem`) exist.
+
+### Changed `ResolveDepthResponse` type definition
+
+The original `ResolveDepthResponse` definition is:
+
+```ts
+type ResolveDepthResponse<T, Depth extends number = 1> = MicroCMSListContent & {
+  [K in keyof T]: T[K] extends infer Prop
+    ? Prop extends MicroCMSRelation<infer R>
+      ? Depth extends 0
+        ? MicroCMSContentId
+        : ResolveDepthResponse<NonNullable<R>, DecrementNum<Depth>>
+      : Prop extends MicroCMSRelation<infer R>[]
+      ? Depth extends 0
+        ? MicroCMSContentId[]
+        : ResolveDepthResponse<NonNullable<R>, DecrementNum<Depth>>[]
+      : Prop
+    : never;
+};
+```
+
+I really respect sir [tsuki-lab](https://github.com/tsuki-lab) who wrote this beautiful type.
+
+However, there is one point that I do not like.
+
+```ts
+MicroCMSListContent & {
+  [K in keyof T]: T[K]...
+}
+```
+
+With this `MicroCMSListContent &`, the return type inference looks like:
+
+```ts
+const { contents } = await client.getList({
+  endpoint: "some-endpoint",
+  queries: { fields: ["name"] }, // only need "name" property
+});
+
+typeof contents: {
+  name: string;
+  publishedAt: string;    // actually does not exists
+  createdAt: string;      // this
+  revisedAt?: string;     // also this
+  updatedAt?: string;     // and this too
+}[]
+
+```
+
+This is different from actual return type:
+
+```ts
+typeof contents: { name: string; }[];
+```
+
+So I modified this type to:
+
+```diff
++ type ResolveDepthResponse<ContentType, Depth extends number = 1> = {
+- type ResolveDepthResponse<T, Depth extends number = 1> = MicroCMSListContent & {
+    [K in keyof ContentType]: ContentType[K] extends infer Props
+      ? Props extends MCRelation<infer Child>
+        ? Depth extends 0
+          ? MCContentId
+          : ResolveDepthResponse<Child, DecrementNum<Depth>>
+        : Props extends MCRelation<infer Child>[]
+        ? Depth extends 0
+          ? MCContentId[]
+          : ResolveDepthResponse<Child, DecrementNum<Depth>>[]
+        : Props
+     : never;
+};
+```

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ type ResolveDepthResponse<T, Depth extends number = 1> = MicroCMSListContent & {
 };
 ```
 
-I really respect sir [tsuki-lab](https://github.com/tsuki-lab) who wrote this beautiful type.
-
 However, there is one point that I do not like.
 
 ```ts
@@ -71,16 +69,4 @@ So I modified this type to:
 ```diff
 + type ResolveDepthResponse<ContentType, Depth extends number = 1> = {
 - type ResolveDepthResponse<T, Depth extends number = 1> = MicroCMSListContent & {
-    [K in keyof ContentType]: ContentType[K] extends infer Props
-      ? Props extends MCRelation<infer Child>
-        ? Depth extends 0
-          ? MCContentId
-          : ResolveDepthResponse<Child, DecrementNum<Depth>>
-        : Props extends MCRelation<infer Child>[]
-        ? Depth extends 0
-          ? MCContentId[]
-          : ResolveDepthResponse<Child, DecrementNum<Depth>>[]
-        : Props
-     : never;
-};
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@darthrommy/microcms-client",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Unofficial microCMS client with type-safety.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@darthrommy/microcms-client",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "description": "Unofficial microCMS client with type-safety.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "module": "./dist/esm/index.mjs",
   "exports": {
     ".": {
       "import": {

--- a/src/type-utils.ts
+++ b/src/type-utils.ts
@@ -1,7 +1,5 @@
 export type KV = Record<string, unknown>;
 
-export type ArrayType<T extends any[]> = T extends (infer U)[] ? U : never;
-
 type DeleteOneItem<Array extends any[]> = Array extends [any, ...infer Rest]
   ? Rest
   : never;

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,8 +86,8 @@ export type WriteResponse = {
 
 // ! GET APIS
 
-export type ResolveDepthResponse<T, Depth extends number = 1> = MCListBase & {
-  [K in keyof T]: T[K] extends infer Props
+export type ResolveDepthResponse<ContentType, Depth extends number = 1> = {
+  [K in keyof ContentType]: ContentType[K] extends infer Props
     ? Props extends MCRelation<infer Child>
       ? Depth extends 0
         ? MCContentId


### PR DESCRIPTION
## Description

the original `ResolveDepthResponse` type:

```ts
type ResolveDepthResponse<T, Depth extends number = 1> = MicroCMSListContent & {
  [K in keyof T]: T[K] extends infer Prop
    ? Prop extends MicroCMSRelation<infer R>
      ? Depth extends 0
        ? MicroCMSContentId
        : ResolveDepthResponse<NonNullable<R>, DecrementNum<Depth>>
      : Prop extends MicroCMSRelation<infer R>[]
      ? Depth extends 0
        ? MicroCMSContentId[]
        : ResolveDepthResponse<NonNullable<R>, DecrementNum<Depth>>[]
      : Prop
    : never;
};
```
Because of the `MicroCMSListContent &`, typescript inferences the return type including the default props(`id`, `createdAt`...) even if they are omitted in the `fields` configuration.

I don't like this behavior.

